### PR TITLE
ci: build modules before deploying to cipprko7t

### DIFF
--- a/.funcignore
+++ b/.funcignore
@@ -1,0 +1,25 @@
+# Excluded from the deployment package by Azure/functions-action
+# (requires respect-funcignore: true in the workflow).
+# Nothing here is read at runtime by the function app.
+
+.git
+.github
+.vscode
+.build
+Tests
+Tools
+Output
+.DS_Store
+.dockerignore
+.editorconfig
+.env.example
+.gitattributes
+.gitignore
+.redocly.lint-ignore.yaml
+redocly.yaml
+cspell.json
+Dockerfile
+docker-compose.yml
+nginx.conf
+license.md
+LICENSE.CustomLicenses

--- a/.gitattributes
+++ b/.gitattributes
@@ -9,5 +9,7 @@
 
 *.json        text eol=lf
 
+.funcignore   text eol=lf
+
 *.png  binary
 *.jpg  binary

--- a/.github/workflows/master_cipprko7t.yml
+++ b/.github/workflows/master_cipprko7t.yml
@@ -17,7 +17,15 @@ jobs:
     runs-on: windows-latest
     steps:
       - name: 'Checkout GitHub Action'
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
+
+      # Concatenates each module's Public/*.ps1 files into a single .psm1 and
+      # generates Config/function-permissions.json. Without this the modules
+      # deploy in source form and every cold start dot-sources 2138 files
+      # individually off the Azure Files content share.
+      - name: 'Build and stage modules'
+        shell: pwsh
+        run: ./Tools/Build-DevApiModules.ps1
 
       - name: 'Run Azure Functions Action'
         uses: Azure/functions-action@v1
@@ -27,3 +35,4 @@ jobs:
           slot-name: 'Production'
           package: ${{ env.AZURE_FUNCTIONAPP_PACKAGE_PATH }}
           publish-profile: ${{ secrets.AZUREAPPSERVICE_PUBLISHPROFILE_18288DA7FB124EA9AD33BC06568A6550 }}
+          respect-funcignore: true


### PR DESCRIPTION
## Problem

The deploy workflow packaged the repo as-is, with no build step. Verified on the live app:

- `wwwroot/Modules/CIPPCore/CIPPCore.psm1` is **557 bytes** — the dot-sourcing stub — with `Public/` sitting next to it
- `wwwroot/Config/function-permissions.json` returns **404**

So `profile.ps1` dot-sources **2,138 individual `.ps1` files** on every cold start, off the Consumption plan's Azure Files content share, and falls back to per-request permission resolution.

This scales with file count, which is why startup has degraded steadily as upstream adds endpoints.

### Measured (local NVMe, PS 7.6.3 — worse on Azure Files)

| | Source form | Built |
|---|---:|---:|
| CIPPCore (481 files) | 8,318 ms | 1,615 ms |
| CIPPHTTP (627 files) | 10,831 ms | 1,802 ms |
| CIPPTests (515 files) | 7,042 ms | 435 ms |
| CIPPStandards (210 files) | 3,269 ms | 472 ms |
| CIPPDB (102 files) | 1,421 ms | 69 ms |
| CIPPActivityTriggers (73) | 1,189 ms | 208 ms |
| CippExtensions (70) | 1,202 ms | 140 ms |
| CIPPAlerts (60) | 988 ms | 96 ms |
| **Total** | **34.3 s** | **4.8 s** |

## Change

- Run `Tools/Build-DevApiModules.ps1` before packaging, matching upstream `publish_release.yml` and `dev_api.yml`. Also generates `Config/function-permissions.json`. Build deps (ModuleBuilder 3.1.8, Metadata, Configuration) are vendored under `Tools/`, so no PSGallery access or network is needed.
- Add `.funcignore` + `respect-funcignore: true`. `respect-funcignore` defaults to `false`, so `.git`, `.github`, `Tests`, `Tools` and docs are currently deployed into `wwwroot`. Confirmed nothing reads those paths at runtime.
- Pin `.funcignore` to `eol=lf` in `.gitattributes`. `* text=lf` enables normalization, so it could otherwise check out CRLF on `windows-latest` and leave `\r` on every pattern, silently voiding the exclusions.
- `actions/checkout` v2 → v4 (v2 runs on EOL Node 16).

No application code changes. ModuleBuilder concatenates the same functions with the same exported names. `version_latest.txt` is untouched, so `profile.ps1` won't take its version-changed branch (no durable clearing).

## Risk / rollback

Steps are sequential and fail-fast: if the build fails, `functions-action` never runs and nothing deploys — the app keeps serving current content.

To roll back, re-run the last good Actions run (checks out that commit, including its build-free workflow, and redeploys), or `git revert` and push. Note the Azure-side route is unavailable: all 10 deployment records are `is_readonly: true` under `GITHUB_ZIP_DEPLOY_FUNCTIONS_V1`, so Deployment Center can't redeploy.

## Verifying after merge

```
https://cipprko7t.scm.azurewebsites.net/api/vfs/site/wwwroot/Modules/CIPPCore/
```

Expect `CIPPCore.psm1` ~2 MB and no `Public/`. The first cold start after any deploy is slow while content settles on the file share — judge from the second onward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)